### PR TITLE
instad of using *args use .join on newlines

### DIFF
--- a/lib/logstash/inputs/util/postgresql_manager.rb
+++ b/lib/logstash/inputs/util/postgresql_manager.rb
@@ -48,7 +48,7 @@ class PostgresqlManager
     rescue => err
       logger.error("%p during test setup: %s" % [ err.class, err.message ])
       logger.error("Error connection database.")
-      logger.error(*err.backtrace)
+      logger.error(err.backtrace.join("\n"))
     end
     return conn
   end

--- a/logstash-input-rbwindow.gemspec
+++ b/logstash-input-rbwindow.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-input-rbwindow'
-  s.version = '1.0.10'
+  s.version = '1.0.11'
   s.licenses = ['GNU Affero General Public License']
   s.summary = "Refresh stores and reset flows and counters."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Using logger.error(*err.backtrace) may cause a crash in the rescue method due to an incorrect number of arguments passed to the logger.error method. To avoid this issue, we should use logger.error(err.backtrace.join("\n")) instead. This will ensure that the backtrace elements are properly combined into a single string before being passed as an argument to logger.error, preventing any potential crash.




